### PR TITLE
Allow (optional) specification of source provider

### DIFF
--- a/Tasks/MSDeployPackageSync/MSDeployPackageSync.ps1
+++ b/Tasks/MSDeployPackageSync/MSDeployPackageSync.ps1
@@ -21,6 +21,9 @@ param
     $Password,
 
     [String] [Parameter(Mandatory = $false)]
+    $SourceProvider,
+
+    [String] [Parameter(Mandatory = $false)]
     $AdditionalArguments
 )
 
@@ -59,6 +62,7 @@ Write-Host "Package= $Package"
 Write-Host "DestinationProvider= $DestinationProvider"
 Write-Host "DestinationComputer= $DestinationComputer"
 Write-Host "Username= $Username"
+Write-Host "SourceProvider= $SourceProvider"
 Write-Host "AdditionalArguments= $AdditionalArguments"
 
 
@@ -89,9 +93,14 @@ if (-not $DestinationComputer -or -not $AuthType) {
     $remoteArguments = ""
 }
 
+if (-not $SourceProvider) {
+    Write-Host "No source provider specified, using package provider for '$packageFile'"
+    $SourceProvider = "package='$packageFile'"
+}
+
 [string[]] $arguments = 
  "-verb:sync",
- "-source:package='$packageFile'",
+ "-source:$SourceProvider",
  "-dest:$DestinationProvider,$($remoteArguments)includeAcls='False'",
 #"-setParam:name='IIS", "Web", "Application", ("Name',value='" + $webApp + "'"),
  "-allowUntrusted"

--- a/Tasks/MSDeployPackageSync/task.json
+++ b/Tasks/MSDeployPackageSync/task.json
@@ -12,7 +12,7 @@
   "author": "Robb Schiefer Jr. (@chief7)",
   "version": {
     "Major": 0,
-    "Minor": 2,
+    "Minor": 3,
     "Patch": 0
   },
   "demands": [
@@ -77,6 +77,16 @@
       "defaultValue": "",
       "required": false,
 	  "properties": {
+        "EditableOptions": "True"
+      }
+    },
+    {
+      "name": "SourceProvider",
+      "type": "string",
+      "label": "SourceProvider",
+      "defaultValue": "The source MSDeploy provider. If blank, the package provider will be used.",
+      "required": false,
+      "properties": {
         "EditableOptions": "True"
       }
     },


### PR DESCRIPTION
Closes #11 

New optional parameter ```SourceProvider``` for other source providers than package. Package is the fall back, if none is specified.