### PR TITLE
Handle errors from the call to cmd.exe

### DIFF
--- a/Tasks/MSDeployPackageSync/MSDeployPackageSync.ps1
+++ b/Tasks/MSDeployPackageSync/MSDeployPackageSync.ps1
@@ -117,6 +117,11 @@ $result = cmd.exe /c "$fullCommand"
 
 Write-Host $result
 
+If ($LASTEXITCODE -eq -1)
+{
+    Write-Host "Deployment failed"
+    throw "MSDeploy command failed.  See logs for details."
+}
 
 Write-Verbose "Leaving script MSDeployPackageSync.ps1"
 


### PR DESCRIPTION
Handle errors from the call to cmd.exe.  Currently any errors that are thrown by MSDeploy are ignored by VSTS and it reports that the release was successful.