### PR TITLE
add powershell demand to task

### DIFF
--- a/Tasks/MSDeployPackageSync/task.json
+++ b/Tasks/MSDeployPackageSync/task.json
@@ -16,7 +16,7 @@
     "Patch": 0
   },
   "demands": [
-    
+    "powershell"
   ],
   "minimumAgentVersion": "1.90.0",
   "inputs": [


### PR DESCRIPTION
This change makes it so that only an agent that's detected as having powershell will be used to execute the task.

We recently setup a mac build agent and added it to our default pool (default because it can run most of our builds). But when we run the ms deploy package sync task it fails with this error on the mac: `The current operating system is not capable of running this task. That typically means the task was written for Windows only. For example, written for Windows Desktop PowerShell.` So I've added the demand for powershell so that our mac agent won't be selected to run the deployment.

FYI, I haven't tested this change, but from what I understand it should work just fine.